### PR TITLE
change column names in the metadata to lower cases

### DIFF
--- a/R/compute_windows.R
+++ b/R/compute_windows.R
@@ -19,6 +19,9 @@ compute_windows <- function(studypopulation, windowmeta,
   # re-write studypopulation to data.table
   studypopulation <- data.table::as.data.table(studypopulation)
 
+  # column names to lower cases
+  colnames(windowmeta) <- tolower(colnames(windowmeta))
+
   # first, check if necessary columns are supplied
   meta_check <- c("window_name","reference_date","start_window","length_window") %in% colnames(windowmeta)
   if(!all(meta_check) == TRUE){


### PR DESCRIPTION
hi @oryan-umcu,

I tried the function with the simulated JnJ study population, and it worked. The only thing is that the column for JnJ meta data is in upper cases while the function checks the names in lower cases as below.

```
  meta_check <- c("window_name","reference_date","start_window","length_window") %in% colnames(windowmeta)
```

So I added this small feature. 
```
  # column names to lower cases
  colnames(windowmeta) <- tolower(colnames(windowmeta))
```
